### PR TITLE
Multi queue scheduling and Dependencies

### DIFF
--- a/libs/mfly_tasker/.vscode/launch.json
+++ b/libs/mfly_tasker/.vscode/launch.json
@@ -8,7 +8,7 @@
             "name": "(Windows) Launch",
             "type": "cppvsdbg",
             "request": "launch",
-            "program": "${workspaceFolder}/a.exe",
+            "program": "${workspaceFolder}/build/Debug/MFLY_Tasker_Test.exe",
             "args": [],
             "stopAtEntry": true,
             "cwd": "${fileDirname}",

--- a/libs/mfly_tasker/.vscode/settings.json
+++ b/libs/mfly_tasker/.vscode/settings.json
@@ -1,6 +1,10 @@
 {
     "cmake.sourceDirectory": "${workspaceFolder}/example",
     "files.associations": {
+        "*.md.html": "markdown",
+        "CMakeLists.txt": "cmake",
+        "*.sq_vert": "glsl",
+        "*.sq_frag": "glsl",
         "algorithm": "cpp",
         "array": "cpp",
         "atomic": "cpp",
@@ -67,6 +71,13 @@
         "xtr1common": "cpp",
         "xtree": "cpp",
         "xutility": "cpp",
-        "unordered_map": "cpp"
-    }
+        "unordered_map": "cpp",
+        "cinttypes": "cpp",
+        "functional": "cpp",
+        "iostream": "cpp",
+        "list": "cpp",
+        "random": "cpp",
+        "xhash": "cpp"
+    },
+    "C_Cpp.default.configurationProvider": "ms-vscode.cmake-tools"
 }

--- a/libs/mfly_tasker/example/base_test.cpp
+++ b/libs/mfly_tasker/example/base_test.cpp
@@ -2,18 +2,24 @@
 #include <../sque_timer/sque_timer.h>
 #include <Windows.h>
 
-// Test to See when is a task worth multithreading
-// Ryzen 9 5900x - 24 logical threads
-// - 1000 iters of waste time ~ .473 microseconds
-// It is worth multithreading when the total cost of repetition of a task
-// is > 4 microseconds, as the task scheduling has its cost as the work setup
-// This just takes into account repetitive step cost
+/*
+    Principles for a task to be worth multithreading
+    - Task Scheduling costs around 15-30 microseconds
+    - Task costs a magnitude more including setup cost
+    - Task is easily independent
+    - Task must be done a lot of times
+        - Or can be done once every some time and result is not critical
+*/
 
-void waste_time()
+#define LOOPS 1000
+
+int waste_time()
 {
     uint32_t sum = 0;
-    for (uint32_t i = 0; i < 1000; ++i)
+    for (uint32_t i = 0; i < 10000000; ++i)
         sum += 1;
+
+    return sum;
 }
 
 class long_task : public mfly::Task
@@ -24,12 +30,22 @@ class long_task : public mfly::Task
 };
 
 
-
-int main(int argc, char** argv)
+void Test0_AvgWasteTimeCost()
 {
-    mfly::Tasker::Init();
+    SQUE_Timer t1;
+    double total_time = 0;
+    for (uint32_t i = 0; i < LOOPS; ++i)
+    {
+        t1.Start();
+        waste_time();
+        t1.Stop();
+        total_time += t1.ReadMicroSec();
+    }
+    printf("Base waste time cost: %f us\n", total_time / (double)LOOPS);
+}
 
-
+void Test1_ScheduleWasteTime()
+{
     SQUE_Timer t1;
 
     t1.Start();
@@ -39,23 +55,63 @@ int main(int argc, char** argv)
 
     // Single Thread 10.000 100microsecond waits
     t1.Start();
-    for (uint32_t i = 0; i < 100; ++i)
+    for (uint32_t i = 0; i < LOOPS; ++i)
     {
         waste_time();
     }
     t1.Stop();
     time = t1.ReadMicroSec();
-    printf("Single Thread: %f\n", t1.ReadMicroSec());
+    printf("Single Thread: %f us\n", time);
 
+    SQUE_Timer t2;
     t1.Start();
-    for (uint32_t i = 0; i < 100; ++i)
+    mfly::TaskID deps_test;
+    mfly::TaskID* p_dep = &deps_test;
+    for (uint32_t i = 0; i < LOOPS; ++i)
     {
-        mfly::Tasker::ScheduleTask(new long_task());
+        mfly::Tasker::ScheduleTask(new long_task(), 0, p_dep, 1);
     }
     while (mfly::Tasker::NumTasks() != 0) {}
     t1.Stop();
     time = t1.ReadMicroSec();
-    printf("Bad Multi Thread: %f\n", t1.ReadMicroSec());
+    printf("Bad Multi Thread: %f us\n", time);
+}
+
+
+void Test2_ScheduleCost()
+{
+    mfly::Tasker::ResetDepCheckTime();
+
+    SQUE_Timer t1;
+    double total_time = 0;
+    uint32_t i = 0;
+    for (i = 0; i < LOOPS; ++i)
+    {
+        t1.Start();
+        mfly::Tasker::ScheduleTask(new long_task());
+        t1.Stop();
+        total_time += t1.ReadMicroSec();
+    }
+    
+    printf("Schedule Cost with Dependency and multiple queues: %f us\n", total_time / (double)LOOPS);
+
+    while (mfly::Tasker::NumTasks() != 0) {};
+
+    printf("Average cost from take to run task (dpendency check): %f us\n", mfly::Tasker::GetDepCheckTime() / double(LOOPS));
+}
+
+int main(int argc, char** argv)
+{
+    mfly::Tasker::Init();
+
+    Test0_AvgWasteTimeCost();
+
+    Test1_ScheduleWasteTime();
+    mfly::Tasker::PrintTotalTasks();
+    Test2_ScheduleCost();
+
+    mfly::Tasker::PrintTotalTasks();
+    
 
     mfly::Tasker::Close();
 

--- a/libs/mfly_tasker/mfly_tasker.cpp
+++ b/libs/mfly_tasker/mfly_tasker.cpp
@@ -1,21 +1,201 @@
 #include "mfly_tasker.h"
 using namespace mfly;
 
-#include <unordered_map>
+//#include <unordered_map>
 
-#include <functional>
+//#include <functional>
 
-template<>
-class std::hash<TaskID>
+#include <../sque_timer/sque_timer.h>
+std::atomic<double> dep_check_time;
+
+double mfly::Tasker::GetDepCheckTime()
 {
-    public:
-    size_t operator()(const TaskID& task) const { return task.id; }
-};
+    return dep_check_time;
+}
+
+void mfly::Tasker::ResetDepCheckTime()
+{
+    dep_check_time = 0;
+}
 
 // Data
 
+static std::vector<mfly::Thread*> threads_c;
+static std::vector<uint32_t> ordered_threads;
+#include <map>
+#include <set>
+//static std::multimap<uint32_t, mfly::Thread*> ordered_threads;
+//static std::set<
+static bool exit_flag = false;
+
+void mfly::Thread::ThreadLoop()
+{
+    while (true)
+    {
+        Task* t = NULL;
+        {
+            std::unique_lock<std::mutex> lock(_schedule_mtx);
+            while (t == NULL && !exit_flag)
+            {
+                if (scheduled_tasks.empty())
+                    _schedule_event.wait(lock);
+                else
+                {
+                    SQUE_Timer t1;
+                    t1.Start();
+                    // Take most prioritary task assigned to the thread
+                    std::unordered_map<TaskID, Task*>::iterator it = tasks.find(scheduled_tasks.top());
+                    t = it->second;
+
+                    // Ask other threads if they have its dependencies or are running them
+                    static bool dep_found = false;
+                    for (uint32_t i = 0; i < threads_c.size(); ++i)
+                    {
+                        for (uint32_t j = 0; j < t->dependencies.size(); ++j)
+                            if (threads_c[i]->tasks.find(t->dependencies[j]) != threads_c[i]->tasks.end())
+                            {
+                                dep_found = true;
+                                break;
+                            }
+                        if (dep_found) break;
+                    }
+
+                    scheduled_tasks.pop();
+
+                    // If a dependency is waiting
+                        // Lower priority by 1
+                        // Reschedule it
+                        // Set t to NULL
+                    if (dep_found)
+                    {
+                        --t->priority;
+                        TaskID tid;
+                        tid.id = it->first.id;
+                        tid.priority = it->first.priority-1;
+                        scheduled_tasks.push(tid);
+                        t = NULL;
+                    }
+                    // ElseIf no dependencies are waiting
+                        // Set task as being ran
+                        // Remove from the map and queue
+                    else
+                    {
+                        is_running_task = true;
+                        running_task = it->first;
+                        tasks.erase(it);
+                    }
+                    t1.Stop();
+                    dep_check_time = dep_check_time + t1.ReadMicroSec();
+                }
+            }
+        }
+        if (exit_flag) break;
+        std::unique_lock<std::mutex> task_lock(t->access_lock);
+        t->run();
+        is_running_task = false;
+    }
+}
+
+bool mfly::Tasker::Init()
+{
+    for (uint16_t i = 0; i < std::thread::hardware_concurrency(); ++i)
+    {
+        Thread* t = new Thread();
+        t->thread = std::thread(&Thread::ThreadLoop, t);
+        threads_c.push_back(t);
+        ordered_threads.push_back(i);
+    }
+
+    return true;
+}
+
+void mfly::Tasker::Update()
+{
+
+}
+
+bool mfly::Tasker::Close()
+{
+    bool ret = true;
+
+    exit_flag = true;
+
+    for (uint16_t i = 0; i < threads_c.size(); ++i)
+    {
+        threads_c[i]->_schedule_event.notify_all();
+        threads_c[i]->thread.join();
+        delete threads_c[i];
+    }
+    threads_c.clear();
+
+    return ret;
+}
+
+
+TaskID mfly::Tasker::ScheduleTask(Task* task, uint16_t priority, TaskID* dependencies, uint32_t num_deps)
+{
+    TaskID key;
+    bool task_queued = false;
+
+    for (uint32_t j = 0; j < num_deps; ++j)
+        task->dependencies.push_back(dependencies[j]);
+    
+    while (!task_queued)
+    {
+        for (uint16_t i = 0; i < threads_c.size(); ++i)
+        {
+            //ordered_threads.begin()->first = 1;
+            mfly::Thread* t = threads_c[ordered_threads[i]];
+            if (!t->_schedule_mtx.try_lock()) continue;
+
+            key.id = pcg32_random();
+            key.priority = priority;
+            t->tasks.insert(std::pair<TaskID, Task*>(key, task));
+            t->scheduled_tasks.push(key);
+            t->_schedule_event.notify_one();
+            task_queued = true;
+            ++t->total_tasks;
+            t->_schedule_mtx.unlock();
+
+            uint32_t t_ind = ordered_threads[i];
+            for (uint16_t j = i; j < ordered_threads.size()-1; ++j)
+                ordered_threads[j] = ordered_threads[j + 1];
+            ordered_threads[ordered_threads.size() - 1] = t_ind;
+
+            break;
+        }
+    }
+    
+    return key;
+}
+
+Task* mfly::Tasker::RetrieveTask(const TaskID& task_key)
+{
+    return NULL;
+}
+
+uint32_t mfly::Tasker::NumTasks()
+{
+    uint32_t ret = 0;
+    for (uint16_t i = 0; i < threads_c.size(); ++i)
+        ret += threads_c[i]->tasks.size();
+
+    return ret;
+}
+
+void mfly::Tasker::PrintTotalTasks()
+{
+    for (uint16_t i = 0; i < threads_c.size(); ++i)
+        printf("Thread %i tasks scheduled: %i\n", i, threads_c[i]->total_tasks);
+}
+
+//-------------------------------------------------------------
+
+/*
 static std::vector<std::thread*> threads;
 static std::unordered_map<TaskID, Task*> tasks;
+static std::mutex _running_mtx;
+static std::unordered_map<TaskID, Task*> running_tasks;
 static std::priority_queue<TaskID> scheduled_tasks;
 static std::mutex _schedule_mtx;
 static std::condition_variable _schedule_event;
@@ -40,6 +220,7 @@ void ThreadLoop()
     while(true)
     {
         Task* t = 0;
+        TaskID tid;
         {
             std::unique_lock<std::mutex> lock(_schedule_mtx);
             while(t == NULL && !exit_flag)
@@ -50,6 +231,17 @@ void ThreadLoop()
                 {
                     auto it = tasks.find(scheduled_tasks.top());
                     t = it->second;
+                    
+                    // Active wait for each dependency
+                    for(uint16_t i = 0; i < t->dependencies.size(); ++i)
+                        // Bad
+                        while(running_tasks.find(t->dependencies[i]) != running_tasks.end()){}
+
+                    {
+                        std::unique_lock<std::mutex> r_lock(_running_mtx);
+                        tid = running_tasks.insert(std::pair<TaskID, Task*>(it->first, t)).first->first;
+                    }
+
                     tasks.erase(it);
                     scheduled_tasks.pop();
                 }
@@ -60,7 +252,12 @@ void ThreadLoop()
 
         // Lock access to task data
         std::unique_lock<std::mutex> task_lock(t->access_lock);
+        
         t->run();
+        {
+            std::unique_lock<std::mutex> r_lock(_running_mtx);
+            running_tasks.erase(running_tasks.find(tid));
+        }
     }
 }
 
@@ -94,13 +291,15 @@ bool Tasker::Close()
     return ret;
 }
 
-TaskID Tasker::ScheduleTask(Task* task, uint16_t priority)
+TaskID Tasker::ScheduleTask(Task* task, uint16_t priority, TaskID* dependencies, uint32_t num_dependencies)
 {
     std::unique_lock<std::mutex> qLock(_schedule_mtx);
     TaskID key;
     key.id = pcg32_random();
     key.priority = priority;
-    tasks.insert(std::pair<TaskID, Task*>(key, task)).second;
+    Task* t = tasks.insert(std::pair<TaskID, Task*>(key, task)).first->second;
+    for(uint32_t i = 0; i < num_dependencies; ++i)
+        t->dependencies.push_back(dependencies[i]);
     scheduled_tasks.push(key);
     _schedule_event.notify_one();
     return key;
@@ -119,5 +318,5 @@ Task* Tasker::RetrieveTask(const TaskID& task_key)
         
     return it->second;
 }
-
+*/
 // Utilities

--- a/libs/mfly_tasker/mfly_tasker.h
+++ b/libs/mfly_tasker/mfly_tasker.h
@@ -5,6 +5,8 @@
 #include <thread>
 #include <mutex>
 #include <condition_variable>
+#include <unordered_map>
+#include <functional>
 #include <pcg/pcg_basic.h>
 
 namespace mfly {
@@ -12,20 +14,52 @@ namespace mfly {
     struct TaskID
     {
         uint32_t id = 0;
-        uint16_t priority = 0;
+        int16_t priority = 0;
         bool operator <(const TaskID& check) const { return this->id < check.id; }
         bool operator >(const TaskID& check) const { return this->id > check.id; }
         bool operator ==(const TaskID& check) const { return this->id == check.id; }
+        size_t operator ()(const TaskID& check) const { return check.id; }
     };
+};
+
+template<>
+class std::hash<mfly::TaskID>
+{
+public:
+    size_t operator()(const mfly::TaskID& task) const { return task.id; }
+};
+
+namespace mfly {
     
+
+    //bool OrderTaskID(const TaskID& t1, const TaskID& t2);
+
     class Task
     {
     public:
         virtual void run() = 0;
         //bool operator <(const Task& check) { return this->id.id < check.id.id; }
     public:
-        std::vector<uint32_t> dependencies;
+        int16_t priority = 0;
         std::mutex access_lock;
+        std::vector<TaskID> dependencies;
+    };
+
+    class Thread
+    {
+    public:
+        void ThreadLoop();
+
+    public:
+        std::mutex _schedule_mtx;
+        std::condition_variable _schedule_event;
+        bool is_running_task = false;
+        TaskID running_task;
+        std::thread thread;
+        std::unordered_multimap<TaskID, Task*> tasks;
+        std::priority_queue<TaskID> scheduled_tasks;
+
+        uint32_t total_tasks = 0;
     };
 
     namespace Tasker
@@ -34,11 +68,15 @@ namespace mfly {
         void Update();
         bool Close();
 
-        TaskID ScheduleTask(Task* task, uint16_t priority = 0);
+        TaskID ScheduleTask(Task* task, uint16_t priority = 0, TaskID* dependencies = nullptr, uint32_t num_deps = 0);
         Task* RetrieveTask(const TaskID& task_key);
         
-        uint32_t NumThreads();
+        //uint32_t NumThreads();
         uint32_t NumTasks();
+        double GetDepCheckTime();
+        void ResetDepCheckTime();
+        void PrintTotalTasks();
+        
     };
 
 


### PR DESCRIPTION
Right now this is actually slower than single queue I think, will add to a branch, test back with a single queue.

For what It seems, at 24threads there is a 10x perf increase with this very bad and basic test. Cost of adding a task is too high at 4us, keep adding tasks, entities and things like that and it will snowball a lot the total time taken really to actually run tasks

There is a ginormouse issue is at checking dependencies. Just checking on one dependency averages a cost of 12us which will increase dramatically with more dependencies. It goes through all threads and checks on each one if the task is being ran or is held there, on a dependency which is not found right now so not even part of a missed task entry and having to take another...

Solution to dependency check would be for the dependency vector to already know at which thread is being held onto, which could be part of a new class called TaskFinder{TaskID, thread_index}
- Would limit search  to a single thread instead of 24
- With task stealing between threads, the children ought to be saved too and then update their dependencies...